### PR TITLE
chore: add rust-toolchain.toml so showcase example compiles

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+# The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
+# https://rust-lang.github.io/rustup/concepts/profiles.html
+profile = "default"
+channel = "1.88.0"


### PR DESCRIPTION

add rust-toolchain.toml so that folks who do not have rust version 1.88.0 will be able to run your showcase example